### PR TITLE
chore: disable some unnecessary CI workflows

### DIFF
--- a/.github/workflows/automerge-crowdin.yml
+++ b/.github/workflows/automerge-crowdin.yml
@@ -5,8 +5,8 @@ on:
   # At 02:00 (UTC) daily
   # https://crontab.guru/#0_2_*_*_*
   # 1 hour before the nightly build
-  schedule:
-    - cron: '0 2 * * *'
+  # schedule:
+  #   - cron: '0 2 * * *'
 
 jobs:
   automerge-crowdin-pr:

--- a/.github/workflows/automerge-translation.yml
+++ b/.github/workflows/automerge-translation.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   # Hourly on workdays
   # https://crontab.guru/#0_*_*_*_1-5
-  schedule:
-    - cron: '0 * * * 1-5'
+  # schedule:
+  #   - cron: '0 * * * 1-5'
 
 jobs:
   automerge-translation-prs:

--- a/.github/workflows/check-translation-files-pr.yml
+++ b/.github/workflows/check-translation-files-pr.yml
@@ -1,9 +1,10 @@
 name: Check translation files
 
 on:
+  workflow_dispatch:
   # Run on pull request and merge queue
-  pull_request:
-  merge_group:
+  # pull_request:
+  # merge_group:
 
 # Cancel any in progress run of the workflow for a given PR
 # This avoids building outdated code

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -5,8 +5,8 @@ on:
   # At 03:00 (UTC) daily
   # https://crontab.guru/#0_3_*_*_*
   # This is a good time for nightly builds, across CET, PST and IST (QA team in India)
-  schedule:
-    - cron: '0 3 * * *'
+  # schedule:
+  #   - cron: '0 3 * * *'
 
 jobs:
   check-date:

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/release-fastlane-ios.yml
     with:
       branch: ${{ github.ref_name }}
-      lanes: '["alfajores", "mainnet"]'
+      lanes: '["mainnet"]'
     secrets:
       gcp-service-account-key: ${{ secrets.GCP_MAINNET_RELEASE_AUTOMATION_SERVICE_ACCOUNT_KEY }}
 
@@ -19,6 +19,6 @@ jobs:
     uses: ./.github/workflows/release-fastlane-android.yml
     with:
       branch: ${{ github.ref_name }}
-      lanes: '["alfajores", "mainnet"]'
+      lanes: '["mainnet"]'
     secrets:
       gcp-service-account-key: ${{ secrets.GCP_MAINNET_RELEASE_AUTOMATION_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-licenses-disclaimer.yml
+++ b/.github/workflows/update-licenses-disclaimer.yml
@@ -1,12 +1,13 @@
 name: Update Licenses and Disclaimer
 
 on:
-  push:
-    # trigger only when the yarn.lock file is modified in main
-    branches:
-      - main
-    paths:
-      - 'yarn.lock'
+  workflow_dispatch:
+  # push:
+  #   # trigger only when the yarn.lock file is modified in main
+  #   branches:
+  #     - main
+  #   paths:
+  #     - 'yarn.lock'
 
 jobs:
   update-licenses-and-disclaimer:


### PR DESCRIPTION
### Description

To keep the changes minimal, I've removed the automated triggers to the unnecessary workflows:
- workflows related to crowdin and translations (these fail when doing the project syncs because of new translations that modify the localised files)
- nightly builds
- productions builds limited to only mainnet (skip alfajores)
- licences update

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
